### PR TITLE
Fix #5. Set limit for admins to 20.

### DIFF
--- a/contracts/access/Roles.sol
+++ b/contracts/access/Roles.sol
@@ -7,7 +7,7 @@ pragma solidity ^0.5.0;
 library Roles {
     struct Role {
         mapping (address => bool) bearer;
-        address[] bearers;
+        address[] potentialBearers;
     }
 
     /**
@@ -18,7 +18,7 @@ library Roles {
         require(!has(role, account));
 
         role.bearer[account] = true;
-        role.bearers.push(account);
+        role.potentialBearers.push(account);
     }
 
     /**
@@ -37,8 +37,8 @@ library Roles {
     function removeAll(Role storage role, address account) internal {
         require(account != address(0));
         require(has(role, account));
-        for (uint i = 0; i < role.bearers.length; i++) {
-            role.bearer[role.bearers[i]] = false;
+        for (uint i = 0; i < role.potentialBearers.length; i++) {
+            role.bearer[role.potentialBearers[i]] = false;
         }
         role.bearer[account] = true;
     }

--- a/contracts/access/Roles.sol
+++ b/contracts/access/Roles.sol
@@ -34,13 +34,14 @@ library Roles {
     /**
      * @dev remove access to this role for all other accounts
      */
-    function removeAll(Role storage role, address account) internal {
+    function reset(Role storage role, address account) internal {
         require(account != address(0));
         require(has(role, account));
+
         for (uint i = 0; i < role.potentialBearers.length; i++) {
             role.bearer[role.potentialBearers[i]] = false;
-
         }
+        
         role.potentialBearers.length = 0;
         add(role, account);
     }

--- a/contracts/access/Roles.sol
+++ b/contracts/access/Roles.sol
@@ -39,8 +39,10 @@ library Roles {
         require(has(role, account));
         for (uint i = 0; i < role.potentialBearers.length; i++) {
             role.bearer[role.potentialBearers[i]] = false;
+
         }
-        role.bearer[account] = true;
+        role.potentialBearers.length = 0;
+        add(role, account);
     }
 
     /**

--- a/contracts/access/roles/WhitelistAdminRole.sol
+++ b/contracts/access/roles/WhitelistAdminRole.sol
@@ -34,6 +34,7 @@ contract WhitelistAdminRole is Ownable {
     }
 
     function addWhitelistAdmin(address account) public onlyAdmin {
+        require(_whitelistAdmins.potentialBearers.length < 20, "Not more than 20 admins are allowed");
         _addWhitelistAdmin(account);
     }
 

--- a/contracts/access/roles/WhitelistAdminRole.sol
+++ b/contracts/access/roles/WhitelistAdminRole.sol
@@ -48,7 +48,7 @@ contract WhitelistAdminRole is Ownable {
     }
 
     function resetWhitelist() public onlyOwner {
-        _whitelistAdmins.removeAll(owner());
+        _whitelistAdmins.reset(owner());
     }
 
     function _addWhitelistAdmin(address account) internal {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2526,6 +2526,11 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
+    "ramda": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ=="
+    },
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -59,5 +59,7 @@
     "solidity-coverage": "^0.5.4",
     "truffle": "^5.0.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "ramda": "^0.26.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "lint:sol": "solhint --max-warnings 0 \"contracts/**/*.sol\"",
     "prepack": "npm run build",
     "version": "scripts/version.js",
-    "test": "npm run compile && scripts/test.sh"
+    "test": "npm run compile && scripts/test.sh",
+    "pretest": "rm -rf ./build"
   },
   "repository": {
     "type": "git",

--- a/test/access/roles/WhitelistAdminRole.test.js
+++ b/test/access/roles/WhitelistAdminRole.test.js
@@ -69,3 +69,15 @@ contract('WhitlistAdminRole', function ([deployer]) {
     await shouldFail.reverting(contract.addWhitelistAdmin(ADDRESSES[20], { from: deployer }));
   });
 });
+
+contract('WhitlistAdminRole', function ([deployer]) {
+  it('should be possible to add more admins after resetting', async () => {
+    const contract = await WhitelistAdminRoleMock.new({ from: deployer });
+
+    add19Admins(contract);
+
+    await contract.resetWhitelist({ from: deployer });
+    await contract.addWhitelistAdmin(ADDRESSES[19], { from: deployer });
+    await contract.addWhitelistAdmin(ADDRESSES[20], { from: deployer });
+  });
+});

--- a/test/access/roles/WhitelistAdminRole.test.js
+++ b/test/access/roles/WhitelistAdminRole.test.js
@@ -2,6 +2,31 @@ const { shouldBehaveLikePublicRole } = require('../../behaviors/access/roles/Pub
 const WhitelistAdminRoleMock = artifacts.require('WhitelistAdminRoleMock');
 const { shouldFail } = require('openzeppelin-test-helpers');
 
+const ADDRESSES = [
+  '0x38F0183C02040fF2C76841c0De3eDf02d6fd4124',
+  '0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c',
+  '0x034082875c5c0f5005271be3fc09b1a8332509Bd',
+  '0x962f7A7146CA5527fB9BF92491da675F3d2De0d8',
+  '0x4906cb897a7583e4c7571E3925c9460182fdf4c8',
+  '0x388B93c535B5C3CCDB14770516d7CAf5590eD009',
+  '0x75cBeF7675Ae9CFba5c935f5034E11A8a0863E64',
+  '0xf9f1CBa474698d50466115Ccc3a3c027b5CbACC8',
+  '0xc664a3AB2089609ff3A00296D747D461A5e239A7',
+  '0x1062602168948351eBeFc926e8D5Cd16c49FF895',
+  '0x6Df8BcaEFd1458Cf44dadC5272FD7e647bA12b0b',
+  '0x20B197f808368b3C5776BaF557bA8902350C68dd',
+  '0x9960918D4812bBC6A43fdA064CbE0Aa02b518D8B',
+  '0xA614C6905C8D77D322460E9B5Bd61544821BbCFe',
+  '0x94268A04181F0Fa4749834AC16532092Ec9c39aB',
+  '0x00ea947F671175055d9287ce0d581F67aA0b886f',
+  '0x5E4D8c3978ae30B3083bbEc7431Bbd49d5ff0E77',
+  '0xa30a26c630293F9dE3f35cDA36B24b5daeB69d01',
+  '0x3eA44e564D176c46ae29c549055012159494Ee48',
+  '0x9f2eC7D17A344E8326bCfaeA62d8Ac7D500b1348',
+  '0x768522fDF347c4aC88D4d78663710e3B98d5973C',
+  '0xB93c495880457A70A523cb702e8Eded3d11089ea',
+];
+
 contract('WhitelistAdminRole', function ([_, whitelistAdmin, otherWhitelistAdmin, ...otherAccounts]) {
   beforeEach(async function () {
     this.contract = await WhitelistAdminRoleMock.new({ from: whitelistAdmin });
@@ -9,14 +34,38 @@ contract('WhitelistAdminRole', function ([_, whitelistAdmin, otherWhitelistAdmin
   });
 
   shouldBehaveLikePublicRole(whitelistAdmin, otherWhitelistAdmin, otherAccounts, 'whitelistAdmin');
-  it('removes role from all other accounts but the whitelister', async function () {
-    await this.contract.resetWhitelist({ from: whitelistAdmin });
-    await shouldFail.reverting(this.contract.onlyWhitelistAdminMock({ from: otherWhitelistAdmin }));
-    await this.contract.onlyWhitelistAdminMock({ from: whitelistAdmin });
+});
+
+contract('WhitelistAdminRole', function ([whitelistAdmin, otherWhitelistAdmin, ...otherAccounts]) {
+  it('removes role from all other accounts but the whitelister', async () => {
+    const contract = await WhitelistAdminRoleMock.new({ from: whitelistAdmin });
+    await contract.addWhitelistAdmin(otherWhitelistAdmin, { from: whitelistAdmin });
+    await contract.addWhitelistAdmin(otherAccounts[0], { from: whitelistAdmin });
+    await contract.resetWhitelist({ from: whitelistAdmin });
+    await shouldFail.reverting(contract.onlyWhitelistAdminMock({ from: otherWhitelistAdmin }));
+    await shouldFail.reverting(contract.onlyWhitelistAdminMock({ from: otherAccounts[0] }));
+    await contract.onlyWhitelistAdminMock({ from: whitelistAdmin });
   });
-  it('Transferring ownership should also add to whitelist', async function () {
+
+  it('Transferring ownership should also add to whitelist', async () => {
     const contract = await WhitelistAdminRoleMock.new({ from: whitelistAdmin });
     await contract.transferOwnership(otherWhitelistAdmin, { from: whitelistAdmin });
     await contract.onlyWhitelistAdminMock({ from: otherWhitelistAdmin });
+  });
+});
+
+const add19Admins = async contract => {
+  const addressesPromise = ADDRESSES.slice(0, 19).map(address => contract.addWhitelistAdmin(address));
+  await Promise.all(addressesPromise);
+};
+
+contract('WhitlistAdminRole', function ([deployer]) {
+  it('should not be possible to add more than 20 admins', async () => {
+    const contract = await WhitelistAdminRoleMock.new({ from: deployer });
+
+    add19Admins(contract);
+
+    await shouldFail.reverting(contract.addWhitelistAdmin(ADDRESSES[19], { from: deployer }));
+    await shouldFail.reverting(contract.addWhitelistAdmin(ADDRESSES[20], { from: deployer }));
   });
 });


### PR DESCRIPTION
Fix #5. Set limit for admins to 20.

Adding a new admin should only be possible as long as there are not more then 20 admins. Resetting the admins or removing an admin only changes the role as an bearer but it does not change the length of the array. 